### PR TITLE
Incremental bug

### DIFF
--- a/s2and/data.py
+++ b/s2and/data.py
@@ -670,6 +670,7 @@ class ANDData:
         low_value: Union[float, int] = 0,
         high_value: Union[float, int] = LARGE_DISTANCE,
         dont_merge_cluster_seeds: bool = True,
+        incremental_dont_use_cluster_seeds: bool = False,
     ) -> Optional[float]:
         """Applies cluster_seeds and generates the default
         constraints which are:
@@ -699,6 +700,8 @@ class ANDData:
         dont_merge_cluster_seeds: bool
             this flag controls whether to use cluster seeds to enforce "dont merge"
             as well as "must merge" constraints
+        incremental_dont_use_cluster_seeds: bool
+            Are we clustering in incremental mode? If so, don't use the cluster seeds that came with the dataset
 
         Returns
         -------
@@ -717,7 +720,9 @@ class ANDData:
             signature_id_1,
         ) in self.cluster_seeds_disallow:
             return CLUSTER_SEEDS_LOOKUP["disallow"]
-        elif self.cluster_seeds_require.get(signature_id_1, -1) == self.cluster_seeds_require.get(signature_id_2, -2):
+        elif (
+            self.cluster_seeds_require.get(signature_id_1, -1) == self.cluster_seeds_require.get(signature_id_2, -2)
+        ) and (not incremental_dont_use_cluster_seeds):
             return CLUSTER_SEEDS_LOOKUP["require"]
         elif (
             dont_merge_cluster_seeds

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -145,6 +145,7 @@ class Clusterer:
         block_dict: Dict,
         dataset: ANDData,
         partial_supervision: Dict[Tuple[str, str], Union[int, float]],
+        incremental_dont_use_cluster_seeds: bool = False,
     ):
         """
         Helper generator function to yield one pair for batch featurization on the fly
@@ -157,6 +158,8 @@ class Clusterer:
             the dataset
         partial_supervision: Dict
             the dictionary of partial supervision provided with this dataset/these blocks
+        incremental_dont_use_cluster_seeds: bool
+            Are we clustering in incremental mode? If so, don't use the cluster seeds that came with the dataset
 
         Returns
         -------
@@ -175,6 +178,7 @@ class Clusterer:
                         signatures[i],
                         signatures[j],
                         dont_merge_cluster_seeds=self.dont_merge_cluster_seeds,
+                        incremental_dont_use_cluster_seeds=incremental_dont_use_cluster_seeds,
                     )
                     if value is not None:
                         label = value - LARGE_INTEGER
@@ -187,6 +191,7 @@ class Clusterer:
         dataset: ANDData,
         partial_supervision: Dict[Tuple[str, str], Union[int, float]] = {},
         disable_tqdm: bool = False,
+        incremental_dont_use_cluster_seeds: bool = False,
     ) -> Dict[str, np.array]:
         """
         Creates the distance matrices for the input blocks.
@@ -203,6 +208,8 @@ class Clusterer:
             the dictionary of partial supervision provided with this dataset/these blocks
         disable_tqdm: bool
             whether to turn off the tqdm progress bars in this function
+        incremental_dont_use_cluster_seeds: bool
+            Are we clustering in incremental mode? If so, don't use the cluster seeds that came with the dataset
 
         Returns
         -------
@@ -224,7 +231,12 @@ class Clusterer:
         logger.info("Pairwise probas initialized, starting making all pairs")
 
         # featurize and predict in batches
-        helper_output = self.distance_matrix_helper(block_dict, dataset, partial_supervision)
+        helper_output = self.distance_matrix_helper(
+            block_dict,
+            dataset,
+            partial_supervision,
+            incremental_dont_use_cluster_seeds=incremental_dont_use_cluster_seeds,
+        )
 
         prev_block_key = ""
         batch_num = 0
@@ -445,6 +457,7 @@ class Clusterer:
         cluster_model_params: Optional[Dict[str, Any]] = None,
         partial_supervision: Dict[Tuple[str, str], Union[int, float]] = {},
         use_s2_clusters: bool = False,
+        incremental_dont_use_cluster_seeds: bool = False,
     ) -> Tuple[Dict[str, List[str]], Optional[Dict[str, np.ndarray]]]:
         """
         Predicts clusters
@@ -463,6 +476,8 @@ class Clusterer:
             the dictionary of partial supervision provided with this dataset/these blocks
         use_s2_clusters: bool
             whether to "predict" using the clusters from Semantic Scholar's old system
+        incremental_dont_use_cluster_seeds: bool
+            Are we clustering in incremental mode? If so, don't use the cluster seeds that came with the dataset
 
         Returns
         -------
@@ -481,7 +496,12 @@ class Clusterer:
             return dict(pred_clusters), dists
 
         if dists is None:
-            dists = self.make_distance_matrices(block_dict, dataset, partial_supervision)
+            dists = self.make_distance_matrices(
+                block_dict,
+                dataset,
+                partial_supervision,
+                incremental_dont_use_cluster_seeds=incremental_dont_use_cluster_seeds,
+            )
 
         for block_key in block_dict.keys():
             if block_key in dists and len(block_dict[block_key]) > 1:
@@ -550,7 +570,9 @@ class Clusterer:
                     cluster_seeds_require_inverse[cluster_num].append(signature_id)
                 for altered_cluster_num in altered_cluster_nums:
                     signature_ids_for_cluster_num = cluster_seeds_require_inverse[altered_cluster_num]
-                    reclustered_output, _ = self.predict({"block": signature_ids_for_cluster_num}, dataset)
+                    reclustered_output, _ = self.predict(
+                        {"block": signature_ids_for_cluster_num}, dataset, incremental_dont_use_cluster_seeds=False
+                    )
                     if len(reclustered_output) > 1:
                         for i, new_cluster_of_signatures in enumerate(reclustered_output.values()):
                             new_cluster_num = str(altered_cluster_num) + f"_{i}"

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -571,7 +571,7 @@ class Clusterer:
                 for altered_cluster_num in altered_cluster_nums:
                     signature_ids_for_cluster_num = cluster_seeds_require_inverse[altered_cluster_num]
                     reclustered_output, _ = self.predict(
-                        {"block": signature_ids_for_cluster_num}, dataset, incremental_dont_use_cluster_seeds=False
+                        {"block": signature_ids_for_cluster_num}, dataset, incremental_dont_use_cluster_seeds=True
                     )
                     if len(reclustered_output) > 1:
                         for i, new_cluster_of_signatures in enumerate(reclustered_output.values()):

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -570,6 +570,11 @@ class Clusterer:
                     cluster_seeds_require_inverse[cluster_num].append(signature_id)
                 for altered_cluster_num in altered_cluster_nums:
                     signature_ids_for_cluster_num = cluster_seeds_require_inverse[altered_cluster_num]
+
+                    # Note: incremental_dont_use_cluster_seeds is set to True, because at this stage of incremental clustering
+                    # we are splitting up the claimed profiles that we received from production so that they align with s2and's predictions.
+                    # When doing this, we don't want to use the passed in cluster seeds, because they reflect the claimed profile, not
+                    # s2and's predictions
                     reclustered_output, _ = self.predict(
                         {"block": signature_ids_for_cluster_num}, dataset, incremental_dont_use_cluster_seeds=True
                     )

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -571,9 +571,10 @@ class Clusterer:
                 for altered_cluster_num in altered_cluster_nums:
                     signature_ids_for_cluster_num = cluster_seeds_require_inverse[altered_cluster_num]
 
-                    # Note: incremental_dont_use_cluster_seeds is set to True, because at this stage of incremental clustering
-                    # we are splitting up the claimed profiles that we received from production so that they align with s2and's predictions.
-                    # When doing this, we don't want to use the passed in cluster seeds, because they reflect the claimed profile, not
+                    # Note: incremental_dont_use_cluster_seeds is set to True, because at this stage
+                    # of incremental clustering we are splitting up the claimed profiles that we received
+                    # from production so that they align with s2and's predictions. When doing this, we
+                    # don't want to use the passed in cluster seeds, because they reflect the claimed profile, not
                     # s2and's predictions
                     reclustered_output, _ = self.predict(
                         {"block": signature_ids_for_cluster_num}, dataset, incremental_dont_use_cluster_seeds=True

--- a/tests/test_cluster_incremental.py
+++ b/tests/test_cluster_incremental.py
@@ -58,5 +58,5 @@ class TestClusterer(unittest.TestCase):
         self.dummy_dataset.cluster_seeds_require = {"1": 0, "2": 0, "5": 0, "6": 1, "7": 1}
         block = ["3", "4", "8"]
         output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
-        expected_output = {"0": ["1", "2", "3", "5", "8"], "1": ["6", "7", "4"]}
+        expected_output = {"0": ["1", "2", "5", "3", "8"], "1": ["6", "7", "4"]}
         assert output == expected_output

--- a/tests/test_cluster_incremental.py
+++ b/tests/test_cluster_incremental.py
@@ -41,6 +41,9 @@ class TestClusterer(unittest.TestCase):
         )
 
     def test_predict_incremental(self):
+        # base clustering of the random model would be
+        # {'0': ['0', '1', '2'], '1': ['3', '4', '5', '8'], '2': ['6', '7']}
+
         block = ["3", "4", "5", "6", "7", "8"]
         output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
         expected_output = {"0": ["6", "7", "5"], "1": ["3", "4", "8"]}
@@ -55,6 +58,5 @@ class TestClusterer(unittest.TestCase):
         self.dummy_dataset.cluster_seeds_require = {"1": 0, "2": 0, "5": 0, "6": 1, "7": 1}
         block = ["3", "4", "8"]
         output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
-        expected_output = {"0": ["1", "2", "5"], "1": ["6", "7", "3", "4"], "2": ["8"]}
-        print(output)
+        expected_output = {"0": ["1", "2", "3", "5", "8"], "1": ["6", "7", "4"]}
         assert output == expected_output


### PR DESCRIPTION
Fixes an issue with the incremental code clustering where we were not splitting claimed profiles properly to align with the expected s2and output. The result was the incompatible clusters resulting from claims  remained incompatible, and new mentions could not be assigned to them.