### PR TITLE
Add extra name incompatibility check

### DIFF
--- a/s2and/model.py
+++ b/s2and/model.py
@@ -686,16 +686,19 @@ class Clusterer:
                                 for signature_id in main_cluster_signatures
                             ]
                         )
+                        all_firsts = {first for first in all_firsts if len(first) > 1}
 
                         # if all the existing first names in the cluster are single characters,
                         # there is nothing else to check
-                        if not all(len(first) == 1 for first in all_firsts):
+                        if len(all_firsts) > 0:
                             first_unassigned = dataset.signatures[
                                 unassigned_signature
                             ].author_info_first_normalized_without_apostrophe
                             match_found = False
                             for first_assigned in all_firsts:
-                                prefix = first_assigned.startswith(first_unassigned)
+                                prefix = first_assigned.startswith(first_unassigned) or first_unassigned.startswith(
+                                    first_assigned
+                                )
                                 known_alias = (first_assigned, first_unassigned) in dataset.name_tuples
 
                                 if prefix or known_alias:

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -713,7 +713,10 @@ class Clusterer:
                                 last = signature.author_info_last
                                 paper_id = signature.paper_id
                                 logger.info(
-                                    f"Incremental clustering prevented a name compatibility issue from being added while clustering {first} {last} on {paper_id}"
+                                    (
+                                        "Incremental clustering prevented a name compatibility issue from being "
+                                        f"added while clustering {first} {last} on {paper_id}"
+                                    )
                                 )
                                 new_name_disallowed = True
 

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -686,7 +686,7 @@ class Clusterer:
                         prefix = first_1.startswith(first_2) or first_2.startswith(first_1)
 
                         if not prefix:
-                            if (not first_1 in all_firsts) and (not first_2 in all_firsts):
+                            if (first_1 not in all_firsts) and (first_2 not in all_firsts):
                                 constraint_found = True
 
                 if constraint_found:

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -675,7 +675,6 @@ class Clusterer:
                 # undo the reclustering step
                 new_name_disallowed = False
                 if best_cluster_id in recluster_map:
-                    print("inside recluster")
                     best_cluster_id = recluster_map[best_cluster_id]  # type: ignore
 
                     if prevent_new_incompatibilities:

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -708,6 +708,13 @@ class Clusterer:
                             # we will allow it to cluster. If it is not, then it has been clustered with a single
                             # character name, and we don't want to allow it
                             if not match_found:
+                                signature = dataset.signatures[unassigned_signature]
+                                first = signature.author_info_first
+                                last = signature.author_info_last
+                                paper_id = signature.paper_id
+                                logger.info(
+                                    f"Incremental clustering prevented a name compatibility issue from being added while clustering {first} {last} on {paper_id}"
+                                )
                                 new_name_disallowed = True
 
                 if new_name_disallowed:

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from s2and.eval import b3_precision_recall_fscore
 from s2and.featurizer import FeaturizationInfo, many_pairs_featurize
 from s2and.data import ANDData
-from s2and.consts import LARGE_INTEGER, DEFAULT_CHUNK_SIZE, LARGE_DISTANCE
+from s2and.consts import LARGE_INTEGER, DEFAULT_CHUNK_SIZE
 
 from typing import Dict, Optional, Any, Union, List, Tuple
 from collections import defaultdict

--- a/s2and/model.py
+++ b/s2and/model.py
@@ -676,17 +676,16 @@ class Clusterer:
                             for signature_id in main_cluster_signatures
                         ]
                     )
-                    for main_cluster_signature in main_cluster_signatures:
-                        first_1 = dataset.signatures[
-                            main_cluster_signature
-                        ].author_info_first_normalized_without_apostrophe
-                        first_2 = dataset.signatures[
-                            unassigned_signature
-                        ].author_info_first_normalized_without_apostrophe
-                        prefix = first_1.startswith(first_2) or first_2.startswith(first_1)
+                    first_unassigned = dataset.signatures[
+                        unassigned_signature
+                    ].author_info_first_normalized_without_apostrophe
+                    for first_assigned in all_firsts:
+                        prefix = first_assigned.startswith(first_unassigned) or first_unassigned.startswith(
+                            first_assigned
+                        )
 
                         if not prefix:
-                            if (first_1 not in all_firsts) and (first_2 not in all_firsts):
+                            if first_unassigned not in all_firsts:
                                 constraint_found = True
 
                 if constraint_found:

--- a/tests/dummy/signatures_incompatible.json
+++ b/tests/dummy/signatures_incompatible.json
@@ -70,5 +70,29 @@
             "2"
         ],
         "sourced_author_source": "ORCID"
+    },
+    "4": {
+        "author_info": {
+            "first": "Alan",
+            "middle": null,
+            "last": "Sattar",
+            "suffix": null,
+            "position": 0,
+            "email": null,
+            "affiliations": [
+                "Random affiliation"
+            ],
+            "block": "a sattar",
+            "estimated_ethnicity": "SLAV",
+            "estimated_gender": "M",
+            "given_block": "a sattar"
+        },
+        "signature_id": "4",
+        "given_name": "Alan Sattar",
+        "paper_id": 21094749,
+        "sourced_author_ids": [
+            "2"
+        ],
+        "sourced_author_source": "ORCID"
     }
 }

--- a/tests/dummy/signatures_incompatible.json
+++ b/tests/dummy/signatures_incompatible.json
@@ -1,7 +1,7 @@
 {
     "1": {
         "author_info": {
-            "first": "Alexander",
+            "first": "A",
             "middle": null,
             "last": "Sattar",
             "suffix": null,
@@ -94,5 +94,29 @@
             "2"
         ],
         "sourced_author_source": "ORCID"
+    },
+    "5": {
+        "author_info": {
+            "first": "A",
+            "middle": null,
+            "last": "Sattar",
+            "suffix": null,
+            "position": 1,
+            "email": null,
+            "affiliations": [
+                "Random affiliation"
+            ],
+            "block": "a sattar",
+            "estimated_ethnicity": "ARAB",
+            "estimated_gender": "M",
+            "given_block": "a sattar"
+        },
+        "signature_id": "5",
+        "given_name": "Alexander Sattar",
+        "paper_id": 27077319,
+        "sourced_author_ids": [
+            "1"
+        ],
+        "sourced_author_source": "DBLP"
     }
 }

--- a/tests/dummy/signatures_incompatible.json
+++ b/tests/dummy/signatures_incompatible.json
@@ -1,0 +1,74 @@
+{
+    "1": {
+        "author_info": {
+            "first": "Alexander",
+            "middle": null,
+            "last": "Sattar",
+            "suffix": null,
+            "position": 1,
+            "email": null,
+            "affiliations": [
+                "Moscow State University"
+            ],
+            "block": "a sattar",
+            "estimated_ethnicity": "ARAB",
+            "estimated_gender": "M",
+            "given_block": "a sattar"
+        },
+        "signature_id": "1",
+        "given_name": "Alexander Sattar",
+        "paper_id": 27077319,
+        "sourced_author_ids": [
+            "1"
+        ],
+        "sourced_author_source": "DBLP"
+    },
+    "2": {
+        "author_info": {
+            "first": "Alan",
+            "middle": null,
+            "last": "Sattar",
+            "suffix": null,
+            "position": 1,
+            "email": null,
+            "affiliations": [
+                "Random affiliation"
+            ],
+            "block": "a sattar",
+            "estimated_ethnicity": "ARAB",
+            "estimated_gender": "M",
+            "given_block": "a sattar"
+        },
+        "signature_id": "2",
+        "given_name": "Alan Sattar",
+        "paper_id": 19901392,
+        "sourced_author_ids": [
+            "2"
+        ],
+        "sourced_author_source": "ORCID"
+    },
+    "3": {
+        "author_info": {
+            "first": "Alec",
+            "middle": null,
+            "last": "Sattar",
+            "suffix": null,
+            "position": 0,
+            "email": null,
+            "affiliations": [
+                "Moscow State University"
+            ],
+            "block": "a sattar",
+            "estimated_ethnicity": "SLAV",
+            "estimated_gender": "M",
+            "given_block": "a sattar"
+        },
+        "signature_id": "3",
+        "given_name": "Alec Sattar",
+        "paper_id": 21094749,
+        "sourced_author_ids": [
+            "2"
+        ],
+        "sourced_author_source": "ORCID"
+    }
+}

--- a/tests/test_cluster_incremental_incompatible.py
+++ b/tests/test_cluster_incremental_incompatible.py
@@ -42,13 +42,14 @@ class TestClusterer(unittest.TestCase):
     def test_predict_incremental(self):
         """
         signature: first name
-        1: Alexander
+        1: A
         2: Alan
         3: Alec
         4: Alan
+        5: A
 
-        Alexander and Alec are an allowed name pair in the name pairs list.
-        Alexander and the first Alan are seeded in a cluster together.
+        A and Alec would be allowed normally.
+        A and the first Alan are seeded in a cluster together.
         The only feature in this test is affiliation similarity, and (1,3) and (2,4) each
         have the same affiliation, and so the pairwise model would rate them as similar.
 
@@ -68,3 +69,16 @@ class TestClusterer(unittest.TestCase):
         )
         expected_output = {"0": ["1", "2", "3", "4"]}
         assert output == expected_output
+
+        # NOTE: this behavior is expected given the current implementation, but is not ideal
+        # because Alec and Alan were simultaneously added to the A cluster. Noting here in case
+        # this issue comes up later so someone knows where to start.
+        # It is testing that when the claimed cluster only contains signatures with a single character
+        # first name, the added incompatibility rule does not prevent adding to the cluster
+        self.dummy_dataset.altered_cluster_signatures = ["1", "5"]
+        self.dummy_dataset.cluster_seeds_require = {"1": 0, "5": 0}
+        block = ["3", "4"]
+        output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
+        expected_output = {"0": ["1", "5", "3", "4"]}
+        assert output == expected_output
+        asdf

--- a/tests/test_cluster_incremental_incompatible.py
+++ b/tests/test_cluster_incremental_incompatible.py
@@ -81,4 +81,3 @@ class TestClusterer(unittest.TestCase):
         output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
         expected_output = {"0": ["1", "5", "3", "4"]}
         assert output == expected_output
-        asdf

--- a/tests/test_cluster_incremental_incompatible.py
+++ b/tests/test_cluster_incremental_incompatible.py
@@ -40,6 +40,23 @@ class TestClusterer(unittest.TestCase):
         )
 
     def test_predict_incremental(self):
+        """
+        signature: first name
+        1: Alexander
+        2: Alan
+        3: Alec
+        4: Alan
+
+        Alexander and Alec are an allowed name pair in the name pairs list.
+        Alexander and the first Alan are seeded in a cluster together.
+        The only feature in this test is affiliation similarity, and (1,3) and (2,4) each
+        have the same affiliation, and so the pairwise model would rate them as similar.
+
+        Given all of this, the expected outcome is that, when we prevent new incompatibilities,
+        Alec does not get added to the seeded cluster, but the second Alan does. When we do not
+        prevent new incompatibilities, all the signatures should end up in a cluster together.
+        """
+
         block = ["3", "4"]
         output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
         expected_output = {"0": ["1", "2", "4"], "1": ["3"]}

--- a/tests/test_cluster_incremental_incompatible.py
+++ b/tests/test_cluster_incremental_incompatible.py
@@ -1,0 +1,53 @@
+import unittest
+import pytest
+import numpy as np
+import pickle
+
+from s2and.data import ANDData
+from s2and.model import Clusterer
+from s2and.featurizer import FeaturizationInfo, many_pairs_featurize
+from s2and.consts import LARGE_DISTANCE
+from sklearn.linear_model import LogisticRegression
+
+
+class TestClusterer(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.dummy_dataset = ANDData(
+            "tests/dummy/signatures_incompatible.json",
+            "tests/dummy/papers.json",
+            clusters="tests/dummy/clusters.json",
+            cluster_seeds={"1": {"2": "require"}},
+            altered_cluster_signatures=["1", "2"],
+            name="dummy",
+            load_name_counts=True,
+        )
+
+        features_to_use = [
+            "affiliation_similarity",
+        ]
+        featurizer_info = FeaturizationInfo(features_to_use=features_to_use)
+        np.random.seed(1)
+        X = np.vstack([np.ones((100, 1)), np.random.uniform(0, 0.5, (100, 1))])
+        y = np.vstack([np.ones((100, 1)), np.zeros((100, 1))]).squeeze()
+        clf = LogisticRegression().fit(X, y)
+        self.dummy_clusterer = Clusterer(
+            featurizer_info=featurizer_info,
+            classifier=clf,
+            n_jobs=1,
+            use_cache=False,
+            use_default_constraints_as_supervision=True,
+        )
+
+    def test_predict_incremental(self):
+        block = ["3"]
+        output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
+        expected_output = {"0": ["1", "2"], "1": ["3"]}
+        assert output == expected_output
+
+        block = ["3"]
+        output = self.dummy_clusterer.predict_incremental(
+            block, self.dummy_dataset, prevent_new_incompatibilities=False
+        )
+        expected_output = {"0": ["1", "2", "3"]}
+        assert output == expected_output

--- a/tests/test_cluster_incremental_incompatible.py
+++ b/tests/test_cluster_incremental_incompatible.py
@@ -40,14 +40,14 @@ class TestClusterer(unittest.TestCase):
         )
 
     def test_predict_incremental(self):
-        block = ["3"]
+        block = ["3", "4"]
         output = self.dummy_clusterer.predict_incremental(block, self.dummy_dataset)
-        expected_output = {"0": ["1", "2"], "1": ["3"]}
+        expected_output = {"0": ["1", "2", "4"], "1": ["3"]}
         assert output == expected_output
 
-        block = ["3"]
+        block = ["3", "4"]
         output = self.dummy_clusterer.predict_incremental(
             block, self.dummy_dataset, prevent_new_incompatibilities=False
         )
-        expected_output = {"0": ["1", "2", "3"]}
+        expected_output = {"0": ["1", "2", "3", "4"]}
         assert output == expected_output


### PR DESCRIPTION
This PR attempts prevent _new_ name incompatibilities from being added to a cluster. So if a claimed cluster contains S Govender and Sharlene Govender, s2and might break that claimed cluster up into two, and then attach Suendharan Govender to the S Govender piece, and then we we remerge, we have a cluster with S Govender, Sharlene Govender, and Suendharan Govender. I suspect this is the issue behind https://github.com/allenai/scholar/issues/27801#issuecomment-847397953, but did not verify that.